### PR TITLE
Support for new Netatmo API calls and support for Windgauge

### DIFF
--- a/.project
+++ b/.project
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>netatmo2wow2</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+	</buildSpec>
+	<natures>
+	</natures>
+</projectDescription>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.ekkelenkamp.netatmo2wow</groupId>
     <artifactId>netatmo2wow</artifactId>
-    <version>2.1</version>
+    <version>2.2</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/com/ekkelenkamp/netatmo2wow/Cli.java
+++ b/src/main/java/com/ekkelenkamp/netatmo2wow/Cli.java
@@ -89,10 +89,12 @@ public class Cli {
         logger.debug("Previous time was: " + new java.util.Date(previousTimestepRead));
         NetatmoDownload download = new NetatmoDownload(netatmoHttpClient);
         WowUpload upload = new WowUpload(previousTimestepRead);
-        try {
+        try 
+        {
             List<Measures> measures = download.downloadMeasures(cmd.getOptionValue("e"), cmd.getOptionValue("p"), cmd.getOptionValue("c"), cmd.getOptionValue("s"), cmd.getOptionValue("t"));
             logger.info("Number of Netatmo measurements read: " + measures.size());
-            if (measures.size() > 0) {
+            if (measures.size() > 0) 
+            {
                 logger.debug("First measurement: " + measures.get(0));
                 logger.debug("Last measurement: " + measures.get(measures.size() - 1));
             }
@@ -100,9 +102,14 @@ public class Cli {
             long lastTimestepRed = wowClient.upload(measures, cmd.getOptionValue("i"), Integer.parseInt(cmd.getOptionValue("a")));
             prefs.put(PREF_NAME, "" + lastTimestepRed);
 
-        } catch (IOException e) {
+        } 
+        catch (IOException e) 
+        {
             throw new RuntimeException(e);
-        } catch (Exception e) {
+        } 
+        catch (Exception e) 
+        {
+        	logger.info(e.getStackTrace());
             throw new RuntimeException(e);
         }
 

--- a/src/main/java/com/ekkelenkamp/netatmo2wow/Info.java
+++ b/src/main/java/com/ekkelenkamp/netatmo2wow/Info.java
@@ -2,6 +2,6 @@ package com.ekkelenkamp.netatmo2wow;
 
 public interface Info {
     String SOFTWARE_NAME = "Netatmo2Wow Java";
-    String SOFTWARE_VERSION = "2.0";
+    String SOFTWARE_VERSION = "2.24";
     String AUTHOR = "Rudie Ekkelenkamp";
 }

--- a/src/main/java/com/ekkelenkamp/netatmo2wow/Main.java
+++ b/src/main/java/com/ekkelenkamp/netatmo2wow/Main.java
@@ -2,9 +2,13 @@ package com.ekkelenkamp.netatmo2wow;
 
 import java.io.IOException;
 
+import org.apache.log4j.BasicConfigurator;
+
 public class Main {
 
     public static void main(String[] args) {
+    	
+    	BasicConfigurator.configure();
         new Cli(args).parse();
     }
 }

--- a/src/main/java/com/ekkelenkamp/netatmo2wow/NetatmoDownload.java
+++ b/src/main/java/com/ekkelenkamp/netatmo2wow/NetatmoDownload.java
@@ -23,6 +23,7 @@ public class NetatmoDownload {
     protected final String URL_REQUEST_TOKEN = URL_BASE + "/oauth2/token";
     protected final String URL_GET_DEVICES_LIST = URL_BASE + "/api/devicelist";
     protected final String URL_GET_MEASURES_LIST = URL_BASE + "/api/getmeasure";
+    protected final String URL_GET_STATION_DATA = URL_BASE + "/api/getstationsdata";
 
     public NetatmoDownload(NetatmoHttpClient netatmoHttpClient) {
         this.netatmoHttpClient = netatmoHttpClient;
@@ -32,45 +33,78 @@ public class NetatmoDownload {
         String url = URL_REQUEST_TOKEN;
         String token = login(username, password, clientId, clientSecret);
         logger.debug("Token: " + token);
+        
         String scale = "max";
         long timePeriod = Long.parseLong(timespan);
-        // netatmo calcuates in seconds, not milliseconds.
+        // netatmo calculates in seconds, not milliseconds.
+        
         long currentDate = ((new java.util.Date().getTime()) / 1000) - timePeriod;
         logger.debug("start time: " + new Date(currentDate * 1000));
         logger.debug("start time seconds: " + currentDate);
-        String deviceMeasureTypes = "Pressure"; // only the pressure is read from the in house device.
-        String moduleMeasureTypes = "Temperature,Humidity,Rain";// from the outside module, we'll read temperature, humidity, rain.
+        
         Device device = getDevices(token);
-        List<Measures> measures = new ArrayList<Measures>();
+        List<Measures> measures = new ArrayList<Measures>();       
         Map<String, List<String>> devices = device.getDevices();
-        for (String dev : devices.keySet()) {
-            measures.addAll(getMeasures(token, dev, null, deviceMeasureTypes, scale, currentDate));
+        
+        Double accumulatedRain = 0.0;
+        for (String dev : devices.keySet()) 
+        {
+        	measures.addAll(getMeasures(token, dev, null, "Pressure" , scale, currentDate, ""));
             List<String> modules = devices.get(dev);
-            for (String module : modules) {
+            
+            for (String module : modules) 
+            {
                 logger.debug("Device: " + device);
-                logger.debug("Module " + module);
+                logger.debug("Module: " + module);
 
-                measures = mergeMeasures(measures, getMeasures(token, dev, module, moduleMeasureTypes, scale, currentDate), TIME_STEP_TOLERANCE);
+                String moduleMeasureTypes = device.getModuleDataType(module);
+                
+                if (moduleMeasureTypes.equals("Rain"))
+                {
+                    List<Measures> accumRain = 
+                    		getMeasures(token, dev, module, "sum_rain", "1day", currentDate, "last");
+                    
+                    if (accumRain.size() > 0)
+                    {
+                    	accumulatedRain = accumRain.get(0).getRainAccumulated();
+                    }
+                }
+
+                List<Measures> newMeasures = getMeasures(token, dev, module, moduleMeasureTypes, scale, currentDate, "");
+                measures = mergeMeasures(measures, newMeasures, TIME_STEP_TOLERANCE);
             }
         }
+        
         Collections.sort(measures);
         calculateAccumulativeRainfail(measures);
+        
+        if (measures.size() > 0)
+        {
+        	measures.get(measures.size() - 1).setRainAccumulated(accumulatedRain);
+        }
+        
         return measures;
     }
 
-    private void calculateAccumulativeRainfail(List<Measures> measures) {
-        for (int i = measures.size() - 1; i > 0; i--) {
+    private void calculateAccumulativeRainfail(List<Measures> measures) 
+    {
+        for (int i = measures.size() - 1; i > 0; i--) 
+        {
             Measures latestMeasure = measures.get(i);
-            // now get all measures before and including this one until we accumulated 1 hour of rainfal.
+            // now get all measures before and including this one until we accumulated 1 hour of rainfall.
             Long start = latestMeasure.getTimestamp();
             Long hourDif = (long) 1000 * 60 * 60; // 1 hour.
             Double accumulatedRainfall = 0.0;
-            for (int j = i; j > 0 && latestMeasure.getRain() != null; j--) {
+            for (int j = i; j > 0 && latestMeasure.getRain() != null; j--) 
+            {
                 Measures currentMeasure = measures.get(j);
-                if (start - currentMeasure.getTimestamp() < hourDif) {
+                if (start - currentMeasure.getTimestamp() < hourDif) 
+                {
                     // no hour passed yet.
                     accumulatedRainfall += currentMeasure.getRain();
-                } else {
+                } 
+                else 
+                {
                     latestMeasure.setRainLastHour(accumulatedRainfall);
                     break;
                 }
@@ -92,16 +126,20 @@ public class NetatmoDownload {
         List<Measures> result = new ArrayList<Measures>();
 
         List<Measures> newMeasures = new ArrayList<Measures>();
-        for (Measures n : newMeasuresList) {
+        for (Measures n : newMeasuresList) 
+        {
             boolean mergedMeasure = false;
-            for (Measures m : measures) {
-                if (Math.abs(m.getTimestamp() - n.getTimestamp()) < timestepTolerance) {
+            for (Measures m : measures) 
+            {
+                if (Math.abs(m.getTimestamp() - n.getTimestamp()) < timestepTolerance) 
+                {
                     n.merge(m);
                     mergedMeasure = true;
                     continue;
                 }
             }
-            if (mergedMeasure) {
+            if (mergedMeasure) 
+            {
                 result.add(n);
             }
         }
@@ -110,52 +148,72 @@ public class NetatmoDownload {
 
     }
 
-    public List<Measures> getMeasures(String token, String device, String module, String measureTypes, String scale, long dateBegin) {
+    public List<Measures> getMeasures(String token, String device, String module, String measureTypes, String scale, long dateBegin, String dateEnd) {
         HashMap<String, String> params = new HashMap<String, String>();
         params.put("access_token", token);
         params.put("device_id", device);
-        if (module != null) {
+        if (module != null) 
+        {
             params.put("module_id", module);
         }
         params.put("type", measureTypes);
         params.put("scale", scale);
-        params.put("date_begin", "" + dateBegin);
+        
+        if (dateEnd == "last")
+        {
+        	params.put("date_end", "" + dateEnd);
+        }
+        
+        params.put("date_begin", "" + dateBegin);        	
         params.put("optimize", "false"); // easy parsing.
 
         List<Measures> measuresList = new ArrayList<Measures>();
-        try {
+        try 
+        {
             JSONParser parser = new JSONParser();
             String result = netatmoHttpClient.post(new URL(URL_GET_MEASURES_LIST), params);
             Object obj = parser.parse(result);
             JSONObject jsonResult = (JSONObject) obj;
-            if (!(jsonResult.get("body") instanceof JSONObject)) {
+            if (!(jsonResult.get("body") instanceof JSONObject)) 
+            {
                 logger.info("No data found");
                 return measuresList;
             }
             JSONObject body = (JSONObject) jsonResult.get("body");
 
-            for (Object o: body.keySet()) {
+            for (Object o: body.keySet()) 
+            {
                 String timeStamp = (String) o;
                 JSONArray valuesArray = (JSONArray) body.get(timeStamp);
                 Measures measures = new Measures();
                 long times = Long.parseLong(timeStamp) * 1000;
                 measures.setTimestamp(times);
-                if (measureTypes.equals("Pressure") && valuesArray.get(0) != null) {
+                
+                if (measureTypes.equals("Pressure") && valuesArray.get(0) != null) 
+                {
                     measures.setPressure(Double.parseDouble("" + valuesArray.get(0)));
-                } else {
-                    if (valuesArray.get(0) != null) {
-                        measures.setTemperature(Double.parseDouble("" + valuesArray.get(0)));
-                    }
+                } 
+                else if (measureTypes.equals("Rain"))
+                {
+                	measures.setRain(Double.parseDouble("" + valuesArray.get(0)));
                 }
-                if (valuesArray.size() > 1 && valuesArray.get(1) != null) {
-                    measures.setHumidity(Double.parseDouble("" + valuesArray.get(1)));
+                else if (measureTypes.equals("sum_rain"))
+        		{
+            		measures.setRainAccumulated(Double.parseDouble("" + valuesArray.get(0)));	
+	    		}
+                else if (measureTypes.equals("Temperature,Humidity"))
+                {
+                	measures.setTemperature(Double.parseDouble("" + valuesArray.get(0)));
+                	measures.setHumidity(Double.parseDouble("" + valuesArray.get(1)));
                 }
-                if (valuesArray.size() > 2 && valuesArray.get(2) != null) {
-                    measures.setRain(Double.parseDouble("" + valuesArray.get(2)));
+                else if (measureTypes.equals("WindStrength,WindAngle,GustStrength,GustAngle"))
+                {
+                	measures.setWind(Double.parseDouble("" + valuesArray.get(0)),
+                			Double.parseDouble("" + valuesArray.get(1)),
+        					Double.parseDouble("" + valuesArray.get(2)),
+							Double.parseDouble("" + valuesArray.get(3)));
                 }
-                if (valuesArray.size() > 3 && valuesArray.get(3) != null) {
-                    measures.setWind(Double.parseDouble("" + valuesArray.get(3)));
-                }
+                
                 measuresList.add(measures);
             }
 
@@ -169,34 +227,46 @@ public class NetatmoDownload {
         Device device = new Device();
         HashMap<String, String> params = new HashMap<String, String>();
         params.put("access_token",token);
-        List<String> devicesList = new ArrayList<String>();
-        try {
+        
+        //List<String> devicesList = new ArrayList<String>();
+        try 
+        {
             JSONParser parser = new JSONParser();
-            String result = netatmoHttpClient.post(new URL(URL_GET_DEVICES_LIST), params);
+            String result = netatmoHttpClient.post(new URL(URL_GET_STATION_DATA), params);
             Object obj = parser.parse(result);
             JSONObject jsonResult = (JSONObject) obj;
-            JSONObject body =  (JSONObject) jsonResult.get("body");
-            JSONArray modules = (JSONArray) body.get("modules");
-            for (int i = 0; i < modules.size(); i++) {
-                JSONObject module = (JSONObject) modules.get(i);
-                String moduleId = (String) module.get("_id");
-                String deviceId = (String) module.get("main_device");
-                JSONArray dataTypes = (JSONArray) module.get("data_type");
-                if (dataTypes.size() > 0) {
-                    String dataType = (String) dataTypes.get(0);
-//                    if (!"Rain".equalsIgnoreCase(dataType)) {
-//                        // currently no support for rain modules.
-                    device.addModuleToDevice(deviceId, moduleId);
-//                    }
-                }
-            }
+            JSONObject body = (JSONObject) jsonResult.get("body");
+            JSONArray devices = (JSONArray) body.get("devices");
+            if (devices.size() > 0)
+            {            	
+            	JSONObject firstDevice = (JSONObject) devices.get(0);            
+            	String deviceId = (String) firstDevice.get("_id");            	
+            	JSONArray modules = (JSONArray) firstDevice.get("modules");
+            	
+            	for (int i = 0; i < modules.size(); i++) 
+            	{
+            		JSONObject module = (JSONObject) modules.get(i);
+            		String moduleId = (String) module.get("_id");
+            		JSONArray dataTypes = (JSONArray) module.get("data_type");
+            		if (dataTypes.size() > 0) 
+            		{
+            			String joinedDataTypes = String.join(",", dataTypes);  
+            			if (joinedDataTypes.equals("Wind"))
+            			{
+            				joinedDataTypes = "WindStrength,WindAngle,GustStrength,GustAngle";
+            			}
+                        device.addModuleToDevice(deviceId, moduleId, joinedDataTypes);
+            		}
+            	}
+            }            
 
             return device;
-        } catch (Exception e) {
+        } 
+        catch (Exception e) 
+        {
             throw new RuntimeException(e);
         }
     }
-
 
     /**
      * This is the first request you have to do before being able to use the API.
@@ -210,6 +280,7 @@ public class NetatmoDownload {
         params.put("client_secret", clientSecret);
         params.put("username", email);
         params.put("password", password);
+        params.put("scope", "read_station");
         try {
             JSONParser parser = new JSONParser();
             String result = netatmoHttpClient.post(new URL(URL_REQUEST_TOKEN), params);

--- a/src/main/java/com/ekkelenkamp/netatmo2wow/NetatmoDownload.java
+++ b/src/main/java/com/ekkelenkamp/netatmo2wow/NetatmoDownload.java
@@ -21,7 +21,7 @@ public class NetatmoDownload {
     // API URLs that will be used for requests, see: http://dev.netatmo.com/doc/restapi.
     protected final String URL_BASE = "https://api.netatmo.net";
     protected final String URL_REQUEST_TOKEN = URL_BASE + "/oauth2/token";
-    protected final String URL_GET_DEVICES_LIST = URL_BASE + "/api/devicelist";
+    //protected final String URL_GET_DEVICES_LIST = URL_BASE + "/api/devicelist";
     protected final String URL_GET_MEASURES_LIST = URL_BASE + "/api/getmeasure";
     protected final String URL_GET_STATION_DATA = URL_BASE + "/api/getstationsdata";
 

--- a/src/main/java/com/ekkelenkamp/netatmo2wow/NetatmoHttpClientImpl.java
+++ b/src/main/java/com/ekkelenkamp/netatmo2wow/NetatmoHttpClientImpl.java
@@ -136,9 +136,7 @@ public class NetatmoHttpClientImpl implements NetatmoHttpClient {
             } else {
                 result.append("&");
             }
-            if (pair.getValue() != null) {
-                result.append(URLEncoder.encode(pair.getKey(), "UTF-8")).append("=").append(URLEncoder.encode(pair.getValue(), "UTF-8"));
-            }
+            result.append(URLEncoder.encode(pair.getKey(), "UTF-8")).append("=").append(URLEncoder.encode(pair.getValue(), "UTF-8"));
         }
 
         return result.toString();

--- a/src/main/java/com/ekkelenkamp/netatmo2wow/NetatmoHttpClientImpl.java
+++ b/src/main/java/com/ekkelenkamp/netatmo2wow/NetatmoHttpClientImpl.java
@@ -136,7 +136,9 @@ public class NetatmoHttpClientImpl implements NetatmoHttpClient {
             } else {
                 result.append("&");
             }
-            result.append(URLEncoder.encode(pair.getKey(), "UTF-8")).append("=").append(URLEncoder.encode(pair.getValue(), "UTF-8"));
+            if (pair.getValue() != null) {
+               result.append(URLEncoder.encode(pair.getKey(), "UTF-8")).append("=").append(URLEncoder.encode(pair.getValue(), "UTF-8"));
+            }        
         }
 
         return result.toString();

--- a/src/main/java/com/ekkelenkamp/netatmo2wow/model/Device.java
+++ b/src/main/java/com/ekkelenkamp/netatmo2wow/model/Device.java
@@ -5,27 +5,40 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-public class Device {
-
+public class Device 
+{
     private Map<String, List<String>> moduleIds = new HashMap<String, List<String>>();
-
-    public void addModuleToDevice(String deviceId, String moduleId) {
-        if (moduleIds.get(deviceId) != null) {
+    private Map<String, String> moduleDataTypes = new HashMap<String, String>();
+    
+    public void addModuleToDevice(String deviceId, String moduleId, String dataType) 
+    {
+        if (moduleIds.get(deviceId) != null) 
+        {
             List<String> modules = moduleIds.get(deviceId);
             modules.add(moduleId);
-        } else {
+            moduleDataTypes.put(moduleId, dataType);
+        } 
+        else 
+        {
             List<String> modules = new ArrayList<String>();
             modules.add(moduleId);
             moduleIds.put(deviceId, modules);
-
+            moduleDataTypes.put(moduleId, dataType);
         }
     }
 
-    public List<String> getModules(String deviceId) {
+    public String getModuleDataType(String moduleId)
+    {
+    	return moduleDataTypes.get(moduleId);
+    }
+    
+    public List<String> getModules(String deviceId) 
+    {
         return moduleIds.get(deviceId);
     }
 
-    public Map<String, List<String>> getDevices() {
+    public Map<String, List<String>> getDevices() 
+    {
         return moduleIds;
-    }
+    }    
 }

--- a/src/main/java/com/ekkelenkamp/netatmo2wow/model/Measures.java
+++ b/src/main/java/com/ekkelenkamp/netatmo2wow/model/Measures.java
@@ -59,7 +59,7 @@ public class Measures implements Comparable<Measures> {
     	{
     		return windStrength;
     	}
-    	// correction factor calculated based on experiments with a handheld anometer. 
+    	// insert correction factor calculated based on experiments with a handheld anometer. 
     	return windStrength;
     }
     
@@ -73,7 +73,7 @@ public class Measures implements Comparable<Measures> {
     	{
     		return windgustStrength;
     	}
-    	// correction factor calculated based on experiments with a handheld anometer. 
+    	// insert correction factor calculated based on experiments with a handheld anometer. 
     	return windgustStrength;
     }
 

--- a/src/main/java/com/ekkelenkamp/netatmo2wow/model/Measures.java
+++ b/src/main/java/com/ekkelenkamp/netatmo2wow/model/Measures.java
@@ -22,14 +22,17 @@ public class Measures implements Comparable<Measures> {
     Double humidity;
     Double rain;
     Double rainLastHour;
-    Double wind;
+    Double windStrength;
+    Double windAngle;
+    Double windgustStrength;
+    Double windgustAngle;
     Double pressure;
-
+    Double rainAccum;
 
     public Long getTimestamp() {
         return timestamp;
     }
-
+    
     public void setTimestamp(Long timestamp) {
         this.timestamp = timestamp;
     }
@@ -50,12 +53,39 @@ public class Measures implements Comparable<Measures> {
         this.humidity = humidity;
     }
 
-    public Double getWind() {
-        return wind;
+    public Double getWindStrength() 
+    {
+    	if (windStrength != null)
+    	{
+    		return windStrength;
+    	}
+    	// correction factor calculated based on experiments with a handheld anometer. 
+    	return windStrength;
+    }
+    
+    public Double getWindAngle() {
+    	return windAngle;
+    }
+    
+    public Double getWindGustStrength() 
+    {
+    	if (windgustStrength != null)
+    	{
+    		return windgustStrength;
+    	}
+    	// correction factor calculated based on experiments with a handheld anometer. 
+    	return windgustStrength;
     }
 
-    public void setWind(Double wind) {
-        this.wind = wind;
+    public Double getWindGustAngle() {
+    	return windgustAngle;
+    }
+    
+    public void setWind(Double windStrength, Double windAngle, Double gustStrength, Double gustAngle) {
+        this.windStrength = windStrength;
+        this.windAngle = windAngle;
+        this.windgustStrength = gustStrength;
+        this.windgustAngle = gustAngle;
     }
 
     public Double getRain() {
@@ -64,6 +94,16 @@ public class Measures implements Comparable<Measures> {
 
     public void setRain(Double rain) {
         this.rain = rain;
+    }
+
+    public void setRainAccumulated(Double rainAccum)
+    {
+    	this.rainAccum = rainAccum;
+    }
+
+    public Double getRainAccumulated()
+    {
+    	return rainAccum;
     }
 
     public Double getPressure() {
@@ -104,18 +144,38 @@ public class Measures implements Comparable<Measures> {
             // todo. Activiate once working.
             map.put("baromin", pressureMillibars);
         }
+        if (getRainAccumulated() != null)
+        {
+        	String rain = new DecimalFormat("0.##", otherSymbols).format(getRainAccumulated() * 0.03937007874015748);
+            map.put("dailyrainin", rain);   // accumulated rainfall in the last day.
+        }
         if (getRainLastHour() != null) {
             // rain is accumulative.
             // convert from mm to inches.
             String rain = new DecimalFormat("0.##", otherSymbols).format(getRainLastHour() * 0.03937007874015748);
             map.put("rainin", rain);   // accumulated rainfall in the last hour.
         }
-        if (getWind() != null) {
+        if (getWindStrength() != null) {
             // windspeedmph convert to miles per hour.
             // mph = kph / 1.609
-            String windspeedMph = new DecimalFormat("0.##", otherSymbols).format(getWind() / 1.609);
+            String windspeedMph = new DecimalFormat("0.##", otherSymbols).format(getWindStrength() / 1.609);
             map.put("windspeedmph", windspeedMph);
         }
+        if (getWindAngle() != null) {
+        	String windAngle = new DecimalFormat("0.##", otherSymbols).format(getWindAngle());
+        	map.put("winddir", windAngle);
+        }
+        if (getWindGustStrength() != null) {
+            // windspeedmph convert to miles per hour.
+            // mph = kph / 1.609
+            String windspeedMph = new DecimalFormat("0.##", otherSymbols).format(getWindGustStrength() / 1.609);
+            map.put("windgustmph", windspeedMph);
+        }
+        if (getWindGustAngle() != null) {
+        	String windAngle = new DecimalFormat("0.##", otherSymbols).format(getWindGustAngle());
+        	map.put("windgustdir", windAngle);
+        }
+        
         dateFormat.setTimeZone(TimeZone.getTimeZone("GMT"));
         String timeText = dateFormat.format(new Date(timestamp));
         map.put("dateutc", timeText);
@@ -144,8 +204,8 @@ public class Measures implements Comparable<Measures> {
             if (measure.getTemperature() != null) {
                 temperature = measure.getTemperature();
             }
-            if (measure.getWind() != null) {
-                wind = measure.getWind();
+            if (measure.getWindStrength() != null) {
+                windStrength = measure.getWindStrength();
             }
 
         } else {
@@ -162,8 +222,8 @@ public class Measures implements Comparable<Measures> {
             if (getTemperature() == null) {
                 temperature = measure.getTemperature();
             }
-            if (getWind() == null) {
-                wind = measure.getWind();
+            if (getWindStrength() == null) {
+                windStrength = measure.getWindStrength();
             }
         }
     }


### PR DESCRIPTION
I've made a fork that takes care of the new Netatmo API calls and avoids using the deprecated ones. It also supports the new(er) Windgauge the company has released about 1,5 years ago. I had already done this like 2 years ago but reforked again to take care of the WOW-id format fix Rudie has applied in version 2.1. Version 2.2 should take the WOW-id format fix into account.